### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,38 +6,38 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-decode_results KEYWORD1
-IRrecv KEYWORD1
-IRsend KEYWORD1
+decode_results	KEYWORD1
+IRrecv	KEYWORD1
+IRsend	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-blink13 KEYWORD2
-decode KEYWORD2
-enableIRIn KEYWORD2
-resume KEYWORD2
-enableIROut KEYWORD2
-sendNEC KEYWORD2
-sendSony KEYWORD2
-sendRaw KEYWORD2
-sendRC5 KEYWORD2
-sendRC6 KEYWORD2
-sendSamsung KEYWORD2
-sendJVC KEYWORD2
-sendPanasonic KEYWORD2
+blink13	KEYWORD2
+decode	KEYWORD2
+enableIRIn	KEYWORD2
+resume	KEYWORD2
+enableIROut	KEYWORD2
+sendNEC	KEYWORD2
+sendSony	KEYWORD2
+sendRaw	KEYWORD2
+sendRC5	KEYWORD2
+sendRC6	KEYWORD2
+sendSamsung	KEYWORD2
+sendJVC	KEYWORD2
+sendPanasonic	KEYWORD2
 #
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-NEC LITERAL1
-SONY LITERAL1
-RC5 LITERAL1
-RC6 LITERAL1
-SAMSUNG LITERAL1
-JVC LITERAL1
-PANASONIC LITERAL1
-UNKNOWN LITERAL1
-REPEAT LITERAL1
+NEC	LITERAL1
+SONY	LITERAL1
+RC5	LITERAL1
+RC6	LITERAL1
+SAMSUNG	LITERAL1
+JVC	LITERAL1
+PANASONIC	LITERAL1
+UNKNOWN	LITERAL1
+REPEAT	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords